### PR TITLE
React deploy

### DIFF
--- a/common/context_processors.py
+++ b/common/context_processors.py
@@ -1,5 +1,12 @@
+from django.conf import settings
+
+
 def constants(request):
     from common.constants import PermissionType
     return {
         "PermissionType": PermissionType,
     }
+
+
+def localhost_context(request):
+    return {'LOCALHOST': settings.LOCALHOST}

--- a/config/settings.py
+++ b/config/settings.py
@@ -95,7 +95,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "build")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -104,6 +104,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "common.context_processors.constants",
+                "common.context_processors.localhost_context",
             ],
         },
     },
@@ -186,7 +187,9 @@ USE_TZ = True
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static")
+    os.path.join(BASE_DIR, "static"),
+    os.path.join(BASE_DIR, "build"),
+    os.path.join(BASE_DIR, "build/static")
 ]
 
 AUTH_USER_MODEL = "common.User"

--- a/esp/templates/esp/scheduler.html
+++ b/esp/templates/esp/scheduler.html
@@ -14,9 +14,14 @@
     <strong>Warning!</strong> This is an active work-in-progress.
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
-
-  <iframe
+{% if LOCALHOST %}
+ <iframe
     src="http://localhost:3000"
     style="border: none; height: calc(100vh - 66px); left: 0; position: absolute; width: 100vw;"
   ></iframe>
+{% else %}
+  <div style="border: none; height: calc(100vh - 66px); left: 0; position: absolute; width: 100vw;">
+    {% include "index.html" %}
+  </div>
+{% endif %}
 {% endblock %}

--- a/esp/views/scheduler.py
+++ b/esp/views/scheduler.py
@@ -24,22 +24,26 @@ class SerializerResponseMixin:
 
 
 class ClassroomApiView(SerializerResponseMixin, BaseListView):
+    #todo: protect with auth and admin permissions
     model = Classroom
     serializer_class = ClassroomSerializer
 
 
 class ClassroomTimeSlotApiView(SerializerResponseMixin, BaseListView):
+    #todo: protect with auth and admin permissions
     model = ClassroomTimeSlot
     serializer_class = ClassroomTimeSlotSerializer
     queryset = ClassroomTimeSlot.objects.all().select_related('course_section__course')
 
 
 class CourseApiView(SerializerResponseMixin, BaseListView):
+    #todo: protect with auth and admin permissions
     model = Course
     serializer_class = CourseSerializer
 
 
 class CourseSectionApiView(SerializerResponseMixin, BaseListView):
+    #todo: protect with auth and admin permissions
     model = CourseSection
     serializer_class = CourseSectionSerializer
 
@@ -50,5 +54,6 @@ class SchedulerView(PermissionRequiredMixin, TemplateView):
 
 
 class TimeSlotApiView(SerializerResponseMixin, BaseListView):
+    #todo: protect with auth and admin permissions
     model = TimeSlot
     serializer_class = TimeSlotSerializer

--- a/src/App.js
+++ b/src/App.js
@@ -336,7 +336,7 @@ export default function App() {
   async function submitData() {
     const data = {"course_id": "","time_slot": selectedClassroomTimeSlots}
     const response = await fetch(
-      `${process.env.REACT_APP_API_BASE_URL}api/v0/classroom-time-slots/`,
+      `${process.env.REACT_APP_API_BASE_URL}/api/v0/classroom-time-slots/`,
       {
         body: JSON.stringify(data),
         headers: {


### PR DESCRIPTION
PR Proposal to render React app by riding on static file build pipeline:
1. `npm run build` builds React app and dumps it into `/build`
2. `python manage.py collectstatic` is now configured to also collect from `/build` and dump it into `/staticfiles`
3. nginx the webserver is serving our static files from `/staticfiles`
4. In Scheduler view HTML, if `LOCALHOST=True`, still use `<iframe src="localhost:3000">` for development purposes 
else if `LOCALHOST=False`, use Django template directive `include` plug in React html into Django template

Alternative proposal:
Use webpack to create a bundle and `django-webpack-loader` to include it into Django