### PR TITLE
inject admin account into docker during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,9 @@ ENV PYTHONBUFFERED 1
 RUN apt update ; apt upgrade -y ; apt install -y python3-dev python3-pip libpq-dev npm; ln -s /usr/bin/python3 /usr/bin/python; pip install -r requirements.txt ; npm install ; python manage.py migrate
 
 EXPOSE 8000
+
+# Inject admin account
+RUN echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', email='admin@esp.mit.edu', password='password')" | python manage.py shell
+
+# Start server
 CMD python manage.py runserver 0.0.0.0:8000

--- a/code/common/managers.py
+++ b/code/common/managers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.base_user import BaseUserManager
 
+from common.constants import UserType
 
 class UserManager(BaseUserManager):
     """
@@ -30,4 +31,4 @@ class UserManager(BaseUserManager):
             raise ValueError('Superuser must have is_staff=True.')
         if extra_fields.get('is_superuser') is not True:
             raise ValueError('Superuser must have is_superuser=True.')
-        return self.create_user(email, password, **extra_fields)
+        return self.create_user(email=email, password=password, user_type=UserType.admin, **extra_fields)

--- a/code/common/models.py
+++ b/code/common/models.py
@@ -40,7 +40,7 @@ class User(AbstractUser, BaseModel):
     verified = models.BooleanField(default=True)
     user_type = models.CharField(max_length=128, choices=UserType.choices)
 
-    REQUIRED_FIELDS = []
+    REQUIRED_FIELDS = ["email"]
     objects = UserManager()
 
     def __str__(self):


### PR DESCRIPTION
Creates a default admin account with username `admin` and password `password` when the docker container is built